### PR TITLE
Lower required active support version

### DIFF
--- a/sanity.gemspec
+++ b/sanity.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 6.0"
+  spec.add_dependency "activesupport", ">= 5.2.5"
 end


### PR DESCRIPTION
# Description

Some of our apps have not been upgraded to rails 6 yet plus it wold be good to support more since I'm not aware of any downsides of using this lower version.