### PR TITLE
(bug) Fix auto serialization with different response objects

### DIFF
--- a/lib/sanity/attributable.rb
+++ b/lib/sanity/attributable.rb
@@ -39,7 +39,7 @@ module Sanity
     def initialize(**args)
       self.class.default_attributes.merge(args).then do |attrs|
         attrs.each do |key, val|
-          define_singleton_method("#{key}=") do |val|
+          define_singleton_method(:"#{key}=") do |val|
             args[key] = val
             attributes[key] = val
           end

--- a/lib/sanity/http/mutation.rb
+++ b/lib/sanity/http/mutation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "set"
+require "set" # rubocop:disable Lint/RedundantRequireStatement
 using Sanity::Refinements::Strings
 using Sanity::Refinements::Arrays
 

--- a/lib/sanity/queryable.rb
+++ b/lib/sanity/queryable.rb
@@ -42,7 +42,7 @@ module Sanity
           define_singleton_method(query) do |**args|
             Module.const_get("Sanity::Http::#{query.to_s.classify}").call(**args.merge(resource_klass: self))
           end
-          define_singleton_method("#{query}_api_endpoint") { QUERY_ENDPOINTS[query] }
+          define_singleton_method(:"#{query}_api_endpoint") { QUERY_ENDPOINTS[query] }
         end
       end
     end

--- a/lib/sanity/serializable.rb
+++ b/lib/sanity/serializable.rb
@@ -50,7 +50,8 @@ module Sanity
 
       def class_serializer
         @class_serializer ||= proc do |results|
-          results["result"].map do |result|
+          key = results.key?("result") ? "result" : "documents"
+          results[key].map do |result|
             attributes = result.slice(*self.attributes.map(&:to_s))
             new(**attributes.transform_keys(&:to_sym))
           end

--- a/test/sanity/resource_test.rb
+++ b/test/sanity/resource_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 describe Sanity::Resource do
-  let(:klass) { Sanity::Resource }
+  let(:klass) { Class.new(Sanity::Resource) { attribute :id; attribute :name } }
   subject { klass.new }
 
   it { assert_respond_to klass, :attributes }
@@ -11,4 +11,29 @@ describe Sanity::Resource do
   it { assert_respond_to klass, :default_serializer }
 
   it { assert_respond_to subject, :attributes }
+
+  describe "auto serialization" do
+    subject {
+      Class.new(Sanity::Resource) do
+        attribute :id
+        attribute :name
+        auto_serialize
+      end
+    }
+
+    let(:result_data) { { "result" => [{ "id" => 1, "name" => "Test Result" }] } }
+    let(:documents_data) { { "documents" => [{ "id" => 2, "name" => "Test Document" }] } }
+
+    it "correctly serializes data with 'result' key" do
+      serialized_objects = subject.default_serializer.call(result_data)
+      assert_equal 1, serialized_objects.first.id
+      assert_equal "Test Result", serialized_objects.first.name
+    end
+
+    it "correctly serializes data with 'documents' key" do
+      serialized_objects = subject.default_serializer.call(documents_data)
+      assert_equal 2, serialized_objects.first.id
+      assert_equal "Test Document", serialized_objects.first.name
+    end
+  end
 end

--- a/test/sanity/resource_test.rb
+++ b/test/sanity/resource_test.rb
@@ -3,7 +3,12 @@
 require "test_helper"
 
 describe Sanity::Resource do
-  let(:klass) { Class.new(Sanity::Resource) { attribute :id; attribute :name } }
+  let(:klass) {
+    Class.new(Sanity::Resource) {
+      attribute :id
+      attribute :name
+    }
+  }
   subject { klass.new }
 
   it { assert_respond_to klass, :attributes }
@@ -21,8 +26,8 @@ describe Sanity::Resource do
       end
     }
 
-    let(:result_data) { { "result" => [{ "id" => 1, "name" => "Test Result" }] } }
-    let(:documents_data) { { "documents" => [{ "id" => 2, "name" => "Test Document" }] } }
+    let(:result_data) { {"result" => [{"id" => 1, "name" => "Test Result"}]} }
+    let(:documents_data) { {"documents" => [{"id" => 2, "name" => "Test Document"}]} }
 
     it "correctly serializes data with 'result' key" do
       serialized_objects = subject.default_serializer.call(result_data)


### PR DESCRIPTION
Sanity sends back different response objects based on the endpoint we're querying.

Resolves #29