### PR TITLE
Global config with singleton instance variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Your initializer `config/initializers/sanity.rb` should look like:
 # `use_global_config` is NOT thread safe. DO NOT use if you intend on changing the
 # config object at anytime within your application's lifecycle.
 #
-# Do not use set `use_global_config` in your application if you're:
+# Do not use `use_global_config` in your application if you're:
 # - Interacting with various Sanity project ids/token
 # - Interacting with multiple API versions
 # - Interacting with calls that sometimes require the use of the CDN and sometimes don't

--- a/README.md
+++ b/README.md
@@ -43,9 +43,19 @@ Sanity.configure do |s|
   s.dataset = "development"
   s.use_cdn = false
 end
+
+# OR
+
+# Sanity.configure do |s|
+#   s.token = ENV.fetch("SANITY_TOKEN", "")
+#   s.api_version = ENV.fetch("SANITY_API_VERSION", "")
+#   s.project_id = ENV.fetch("SANITY_PROJECT_ID", "")
+#   s.dataset = ENV.fetch("SANITY_DATASET", "")
+#   s.use_cdn = ENV.fetch("SANITY_USE_CDN", false)
+# end
 ```
 
-or you can set the following ENV variables at runtime:
+or you can set the following ENV variables at runtime without any initializer:
 
 ```bash
 SANITY_TOKEN="yoursupersecrettoken"
@@ -55,9 +65,9 @@ SANITY_DATASET="development"
 SANITY_USE_CDN="false"
 ```
 
-The configuration object is thread safe meaning you can connect to multiple different projects and/or API variations across any number of threads. A real world scenario when working with Sanity may require that you sometimes interact with the [CDN based API](https://www.sanity.io/docs/api-cdn) and sometimes the non-CDN based API. Using ENV variables combined with our thread safe configuration object gives you the ultimate flexibility.
+The configuration object is thread safe by default meaning you can connect to multiple different projects and/or API variations across any number of threads. A real world scenario when working with Sanity may require that you sometimes interact with the [CDN based API](https://www.sanity.io/docs/api-cdn) and sometimes the non-CDN based API. Using ENV variables combined with the thread safe configuration object gives you the ultimate flexibility.
 
-If you're using this gem in a Rails application AND you're interacting with only ONE set of configuration you can make the gem use the global configuration by setting the `use_global_config` option to `true`. 
+If you're using this gem in a Rails application AND you're interacting with only ONE set of configuration you can make the gem use the global configuration by setting the `use_global_config` option to `true`.
 
 Your initializer `config/initializers/sanity.rb` should look like:
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ gem 'sanity-ruby'
 Setup your configuration. If using in Rails, consider setting this in an initializer:
 
 ```ruby
+# config/initializers/sanity.rb
 Sanity.configure do |s|
   s.token = "yoursupersecrettoken"
   s.api_version = "v2021-03-25"
@@ -54,7 +55,30 @@ SANITY_DATASET="development"
 SANITY_USE_CDN="false"
 ```
 
-The configuration object is thread safe meaning you can connect to multiple different projects across multiple threads. This may be useful if your application is interacting with multiple different Sanity projects.
+The configuration object is thread safe meaning you can connect to multiple different projects and/or API variations across any number of threads. A real world scenario when working with Sanity may require that you sometimes interact with the [CDN based API](https://www.sanity.io/docs/api-cdn) and sometimes the non-CDN based API. Using ENV variables combined with our thread safe configuration object gives you the ultimate flexibility.
+
+If you're using this gem in a Rails application AND you're interacting with only ONE set of configuration you can make the gem use the global configuration by setting the `use_global_config` option to `true`. 
+
+Your initializer `config/initializers/sanity.rb` should look like:
+
+```ruby
+# `use_global_config` is NOT thread safe. DO NOT use if you intend on changing the
+# config object at anytime within your application's lifecycle.
+#
+# Do not use set `use_global_config` in your application if you're:
+# - Interacting with various Sanity project ids/token
+# - Interacting with multiple API versions
+# - Interacting with calls that sometimes require the use of the CDN and sometimes don't
+
+Sanity.use_global_config = true
+Sanity.configure do |s|
+  s.token = "yoursupersecrettoken"
+  s.api_version = "v2021-03-25"
+  s.project_id = "1234"
+  s.dataset = "development"
+  s.use_cdn = false
+end
+```
 
 To create a new document:
 

--- a/lib/sanity/configuration.rb
+++ b/lib/sanity/configuration.rb
@@ -29,21 +29,36 @@ module Sanity
     def api_subdomain
       use_cdn ? "apicdn" : "api"
     end
-  end
 
-  def self.configuration
-    Thread.current[:sanity_configuration] ||= Configuration.new
+    def to_h
+      instance_variables.each_with_object({}) do |var, obj|
+        obj[var.to_s.delete("@").to_sym] = instance_variable_get(var)
+      end
+    end
   end
 
   class << self
+    attr_accessor :use_global_config
+
+    def configuration
+      if use_global_config
+        @configuration ||= Configuration.new
+      else
+        Thread.current[:sanity_configuration] ||= Configuration.new
+      end
+    end
     alias_method :config, :configuration
-  end
 
-  def self.configuration=(config)
-    Thread.current[:sanity_configuration] = config
-  end
+    def configuration=(config)
+      if use_global_config
+        @configuration = config
+      else
+        Thread.current[:sanity_configuration] = config
+      end
+    end
 
-  def self.configure
-    yield configuration
+    def configure
+      yield configuration
+    end
   end
 end

--- a/test/sanity/configuration_test.rb
+++ b/test/sanity/configuration_test.rb
@@ -23,39 +23,85 @@ describe Sanity::Configuration do
   end
 
   describe "thread safety" do
-    it "maintains separate configurations across threads" do
-      threads = []
-      configurations = []
-
-      4.times do |i|
-        threads << Thread.new do
-          Sanity.configure do |config|
-            config.project_id = "Project#{i}"
-            config.dataset = "Dataset#{i}"
-            config.api_version = "v#{i}"
-            config.token = "Token#{i}"
-            config.use_cdn = i.even?
-          end
-
-          configurations << {
-            index: i,
-            project_id: Sanity.configuration.project_id,
-            dataset: Sanity.configuration.dataset,
-            api_version: Sanity.configuration.api_version,
-            token: Sanity.configuration.token,
-            use_cdn: Sanity.configuration.use_cdn
-          }
+    context "when use_global_config is nil" do
+      before do
+        Sanity.use_global_config = false
+        Sanity.configure do |config|
+          config.project_id = "Project 20"
+          config.dataset = "Dataset 20"
+          config.api_version = "v20"
+          config.token = "Token 20"
+          config.use_cdn = nil
         end
       end
 
-      threads.each(&:join)
+      it "maintains separate configurations across threads" do
+        threads = []
+        configurations = []
 
-      configurations.sort_by { |config| config[:index] }.each_with_index do |config, i|
-        assert_equal "Project#{i}", config[:project_id]
-        assert_equal "Dataset#{i}", config[:dataset]
-        assert_equal "v#{i}", config[:api_version]
-        assert_equal "Token#{i}", config[:token]
-        assert_equal i.even?, config[:use_cdn]
+        4.times do |i|
+          threads << Thread.new do
+            Sanity.configure do |config|
+              config.project_id = "Project#{i}"
+              config.dataset = "Dataset#{i}"
+              config.api_version = "v#{i}"
+              config.token = "Token#{i}"
+              config.use_cdn = i.even?
+            end
+
+            configurations << {
+              index: i,
+              **Sanity.config.to_h
+            }
+          end
+        end
+
+        threads.each(&:join)
+
+        configurations.sort_by { |config| config[:index] }.each_with_index do |config, i|
+          assert_equal "Project#{i}", config[:project_id]
+          assert_equal "Dataset#{i}", config[:dataset]
+          assert_equal "v#{i}", config[:api_version]
+          assert_equal "Token#{i}", config[:token]
+          assert_equal i.even?, config[:use_cdn]
+        end
+      end
+    end
+
+    context "when use_global_config is true" do
+      before do
+        Sanity.use_global_config = true
+        Sanity.configure do |config|
+          config.project_id = "Project 1"
+          config.dataset = "Dataset 1"
+          config.api_version = "v1"
+          config.token = "Token 1"
+          config.use_cdn = true
+        end
+      end
+
+      it "maintains config across threads" do
+        threads = []
+        configurations = []
+
+        4.times do |i|
+          threads << Thread.new do
+            configurations << {
+              index: i,
+              **Sanity.config.to_h
+            }
+          end
+        end
+
+        threads.each(&:join)
+
+        configurations.each do |config|
+          assert_equal "Project 1", config[:project_id]
+          assert_equal "Dataset 1", config[:dataset]
+          assert_equal "v1", config[:api_version]
+          assert_equal "Token 1", config[:token]
+          assert_equal true, config[:use_cdn]
+        end
       end
     end
   end


### PR DESCRIPTION
Interacting with a single Sanity project in a multi-threaded environment without configuration relying on SANITY_* ENV vars is difficult.

This is specifically true within a Rails app while using the conventional initializers (without relying on ENV vars).

Allow a user to set:
Sanity.use_global_config = true

This stores the configuration in a singleton instance variable for r/w access after the Rails::Engine.load_config_initializer method is run.

Resolves #36