### PR TITLE
serialize hashes and arrays in variables

### DIFF
--- a/lib/sanity/http/where.rb
+++ b/lib/sanity/http/where.rb
@@ -41,7 +41,7 @@ module Sanity
         else
           {}.tap do |hash|
             variables.each do |key, value|
-              hash["$#{key}"] = "\"#{value}\""
+              hash["$#{key}"] = serialize_variable_value(value)
             end
           end
         end.merge(query: groq_query)
@@ -55,6 +55,17 @@ module Sanity
         return unless use_post
 
         query_and_variables.to_json
+      end
+
+      def serialize_variable_value(value)
+        case value
+        when String
+          "\"#{value}\""
+        when Array, Hash
+          value.to_json
+        else
+          value.to_s
+        end
       end
     end
   end


### PR DESCRIPTION
In a rails console if I do this:

```
groq = "*[ _id in $uuids] { _id }"
variables = {uuids: ["15af9fc6-bbaf-4368-ab4d-62206a35f5f5", "2703512d-c1c7-49e4-9d20-c70e85cf2ec3", "46071c04-756b-4ad3-9a8e-2cad0652a24d", "7a02ec75-ba7c-4a44-927c-1a56459cda7e", "c2f69b8b-7f24-45d5-be2c-eb48c2b12901", "fe842bc1-d532-498c-be2f-466ce924b67e"]}
# then 
Sanity::Document.where(groq: groq, variables: variables)
# => 
{"error"=>
  {"description"=>
    "Unable to parse value of \"$uuids=\"[\"15af9fc6-bbaf-4368-ab4d-62206a35f5f5\", \"2703512d-c1c7-49e4-9d20-c70e85cf2ec3\", \"46071c04-756b-4ad3-9a8e-2cad0652a24d\", \"7a02ec75-ba7c-4a44-927c-1a56459cda7e\", \"c2f
69b8b-7f24-45d5-be2c-eb48c2b12901\", \"fe842bc1-d532-498c-be2f-466ce924b67e\"]\"\". Please quote string values.",
   "type"=>"httpBadRequest"}}
```

This fixes that issue