### PR TITLE
Small updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,9 @@ gem "guard-minitest"
 gem "yard"
 
 gem "standard"
+
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0')
+  gem 'ffi', '~> 1.16.3'
+else
+  gem 'ffi'
+end

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ The library also provides other features, like:
 - A small DSL around GROQ queries
 
 > [!NOTE]
-> This gem was originally developed in early 2021 to facilitate Morning Brew's content migration from Rails to Sanity. It was subsequently used to enable interaction between Morning Brew's Rails-based Advertising CMS and their Sanity-based Editorial CMS for another ~year. The gem is no longer actively used in production as the Rails applications have since been deprecated, but it remains available as an open-source solution for Rails-Sanity integrations.
+> This gem was originally developed in early 2021 to facilitate Morning Brew's content migration from Rails to Sanity. It was subsequently used to enable interaction between Morning Brew's Rails-based Advertising CMS and their Sanity-based Editorial CMS for another ~year. The gem is no longer actively used in production as the Rails applications have since been deprecated, but it remains available as an open-source solution for Ruby - Sanity integrations.
 
 > [!WARNING]
-> If you're looking for a way to host Sanity within a Rails application, this gem is not the solution.
+> If you're looking for a way to embed Sanity Studio within a Rails application, this gem is not the solution.
 
 ## Contents
 

--- a/lib/sanity.rb
+++ b/lib/sanity.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "logger"
 require "active_model"
 require "forwardable"
 require "sanity/refinements"


### PR DESCRIPTION
- Latest ffi (1.17.1) requires RubyGems >= 3.3+. Pin on older ruby versions
- README clarifications
- ActiveSupport 6.1.x expects Logger to be loaded. Add explicit require