### PR TITLE
Define Queryable Type

### DIFF
--- a/lib/sanity/queryable.rb
+++ b/lib/sanity/queryable.rb
@@ -34,6 +34,14 @@ module Sanity
         where: "data/query"
       }.freeze
 
+      def sanity_type
+        @sanity_type || Sanity::TypeHelper.default_type(self)
+      end
+
+      def sanity_type=(_type)
+        @sanity_type = _type
+      end
+
       private
 
       def queryable(**options)
@@ -44,7 +52,7 @@ module Sanity
 
       def define_query_method(query)
         define_singleton_method(query) do |**args|
-          default_type = args.key?(:_type) ? args[:_type] : Sanity::TypeHelper.default_type(self)
+          default_type = args.key?(:_type) ? args[:_type] : sanity_type
           default_args = {resource_klass: self, _type: default_type}.compact
           Module.const_get("Sanity::Http::#{query.to_s.classify}").call(**default_args.merge(args))
         end

--- a/test/sanity/queryable_test.rb
+++ b/test/sanity/queryable_test.rb
@@ -56,5 +56,32 @@ describe Sanity::Queryable do
       it { refute_respond_to subject, :find }
       it { refute_respond_to subject, :where }
     end
+
+    context "no sanity_type defined" do
+      subject {
+        Class.new do
+          include Sanity::Queryable
+          queryable
+        end
+      }
+
+      it "returns lower class name" do
+        assert_equal "class", subject.sanity_type
+      end
+    end
+
+    context "sanity_type defined" do
+      subject {
+        Class.new do
+          include Sanity::Queryable
+          queryable
+          sanity_type="a_sanity_resource"
+        end
+      }
+
+      it "returns lower class name" do
+        assert_equal "a_sanity_resource", subject.sanity_type
+      end
+    end
   end
 end


### PR DESCRIPTION
Sometimes class names will not match the sanity resource document. When this happens we want to allow for the sanity type to explicitly be defined.