### PR TITLE
Allow symbol variable and type aliases

### DIFF
--- a/lib/sanity/helpers/type_helper.rb
+++ b/lib/sanity/helpers/type_helper.rb
@@ -5,12 +5,7 @@ module Sanity
     def self.default_type(klass)
       return nil if klass == Sanity::Document
 
-      type =
-        if klass.respond_to?(:document_type) && klass.document_type
-          klass.document_type.to_s
-        else
-          klass.to_s
-        end
+      type = (klass.try(:document_type) || klass).to_s
 
       type[0].downcase + type[1..]
     end

--- a/lib/sanity/helpers/type_helper.rb
+++ b/lib/sanity/helpers/type_helper.rb
@@ -5,7 +5,13 @@ module Sanity
     def self.default_type(klass)
       return nil if klass == Sanity::Document
 
-      type = klass.to_s
+      type =
+        if klass.respond_to?(:document_type) && klass.document_type
+          klass.document_type.to_s
+        else
+          klass.to_s
+        end
+
       type[0].downcase + type[1..]
     end
   end

--- a/lib/sanity/http/where.rb
+++ b/lib/sanity/http/where.rb
@@ -59,7 +59,7 @@ module Sanity
 
       def serialize_variable_value(value)
         case value
-        when String
+        when String, Symbol
           "\"#{value}\""
         when Array, Hash
           value.to_json

--- a/lib/sanity/queryable.rb
+++ b/lib/sanity/queryable.rb
@@ -28,6 +28,8 @@ module Sanity
     module ClassMethods
       DEFAULT_KLASS_QUERIES = %i[find where].freeze
 
+      attr_accessor :document_type
+
       # See https://www.sanity.io/docs/http-query & https://www.sanity.io/docs/http-doc
       QUERY_ENDPOINTS = {
         find: "data/doc",

--- a/test/sanity/helpers/type_helper_test.rb
+++ b/test/sanity/helpers/type_helper_test.rb
@@ -15,5 +15,27 @@ describe Sanity::TypeHelper do
       subject { Foobar }
       it { assert_equal "foobar", Sanity::TypeHelper.default_type(subject) }
     end
+
+    context "Sanity::Document" do
+      context "without a custom document_type" do
+        subject do
+          Quux = Class.new(Sanity::Document)
+          Quux
+        end
+
+        it { assert_equal "quux", Sanity::TypeHelper.default_type(subject) }
+      end
+
+      context "with custom document_type" do
+        subject do
+          BarBaz = Class.new(Sanity::Document) do
+            self.document_type = "custom_type"
+          end
+          BarBaz
+        end
+
+        it { assert_equal "custom_type", Sanity::TypeHelper.default_type(subject) }
+      end
+    end
   end
 end

--- a/test/sanity/http/where_test.rb
+++ b/test/sanity/http/where_test.rb
@@ -24,6 +24,7 @@ describe Sanity::Http::Where do
             array_of_strings: ["foo", "bar"],
             hash_var: {"foo" => "bar"},
             number_var: 42,
+            symbol_var: :symbolized_variable,
             boolean_var: true
           }
         end
@@ -38,6 +39,7 @@ describe Sanity::Http::Where do
           assert_includes decoded_query, "$hash_var={\"foo\":\"bar\"}"
           assert_includes decoded_query, "$number_var=42"
           assert_includes decoded_query, "$boolean_var=true"
+          assert_includes decoded_query, "$symbol_var=\"symbolized_variable\""
         end
       end
     end

--- a/test/sanity/resources/document_test.rb
+++ b/test/sanity/resources/document_test.rb
@@ -22,4 +22,23 @@ describe Sanity::Document do
 
   it { assert_respond_to klass, :find }
   it { assert_respond_to klass, :where }
+
+  describe ".document_type" do
+    it "allows setting a custom type name" do
+      klass.document_type = "custom_type"
+      assert_equal "custom_type", klass.document_type
+    end
+
+    it "returns nil when document_type is not set" do
+      new_klass = Class.new(Sanity::Document)
+      assert_nil new_klass.document_type
+    end
+
+    it "allows setting document_type to nil" do
+      klass.document_type = "custom_type"
+      assert_equal "custom_type", klass.document_type
+      klass.document_type = nil
+      assert_nil klass.document_type
+    end
+  end
 end


### PR DESCRIPTION
Two small quality of life improvements:

1. Allow symbols to be treated like strings when passed as variables in queries
2. Add a class level `attr_accessor` (`:document_type`) on `Sanity::Document` (via `Queryable`).
  a. This will act similar to how for an ActiveRecord model `self.table_name = ...` can be defined to associate a model with a table that does not follow the standard conventions. In our use case, all of our CMS classes are namespaced in our rails app, so this will simplify things a lot. 